### PR TITLE
Disable `webhookReply` by default

### DIFF
--- a/core/network/client.js
+++ b/core/network/client.js
@@ -34,7 +34,7 @@ const DEFAULT_EXTENSIONS = {
 
 const DEFAULT_OPTIONS = {
   apiRoot: 'https://api.telegram.org',
-  webhookReply: true,
+  webhookReply: false,
   agent: new https.Agent({
     keepAlive: true,
     keepAliveMsecs: 10000


### PR DESCRIPTION
# Description

webhookReply is an [endless source of issues](https://github.com/telegraf/telegraf/issues?q=webhookReply). To increase reliability (and reduce the number of "bug" reports), I suggest disabling it by default. Instead, I'd encourage people to enable it on per-call basis and document the gotchas:

1. Errors in the webhookReply calls cannot be reported.
2. webhookReply calls break ordering by resolving before bot API has a chance to process them (#1167, #1086).
3. webhookReply call confirms the update, which means it won't be processed again if bot crashes.


## Type of change

- [x] Feature fix